### PR TITLE
Fixed the left indent bug

### DIFF
--- a/library/project.properties
+++ b/library/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-15
+target=android-19
 android.library=true

--- a/library/src/com/emilsjolander/components/StickyScrollViewItems/StickyScrollView.java
+++ b/library/src/com/emilsjolander/components/StickyScrollViewItems/StickyScrollView.java
@@ -37,6 +37,7 @@ public class StickyScrollView extends ScrollView {
 	private ArrayList<View> stickyViews;
 	private View currentlyStickingView;
 	private float stickyViewTopOffset;
+	private int stickyViewLeftOffset;
 	private boolean redirectTouchesToStickyView;
 	private boolean clippingToPadding;
 	private boolean clipToPaddingHasBeenSet;
@@ -160,7 +161,8 @@ public class StickyScrollView extends ScrollView {
 		super.dispatchDraw(canvas);
 		if(currentlyStickingView != null){
 			canvas.save();
-			canvas.translate(getPaddingLeft(), getScrollY() + stickyViewTopOffset + (clippingToPadding ? getPaddingTop() : 0));
+			canvas.translate(getPaddingLeft() + stickyViewLeftOffset,
+					getScrollY() + stickyViewTopOffset + (clippingToPadding ? getPaddingTop() : 0));
 			canvas.clipRect(0, (clippingToPadding ? -stickyViewTopOffset : 0), getWidth(), currentlyStickingView.getHeight());
 			if(getStringTagForView(currentlyStickingView).contains(FLAG_HASTRANSPARANCY)){
 				showView(currentlyStickingView);
@@ -249,6 +251,8 @@ public class StickyScrollView extends ScrollView {
 				if(currentlyStickingView!=null){
 					stopStickingCurrentlyStickingView();
 				}
+				// only compute the left offset when we start sticking.
+				stickyViewLeftOffset = getLeftForViewRelativeOnlyChild(viewThatShouldStick);
 				startStickingView(viewThatShouldStick);
 			}
 		}else if(currentlyStickingView!=null){


### PR DESCRIPTION
Now, if a sticky view is indented from the left of the screen, when it is stuck that view will be indented the same.
