### PR TITLE
Fix: views might be null during onLayout.

### DIFF
--- a/library/src/com/emilsjolander/components/StickyScrollViewItems/StickyScrollView.java
+++ b/library/src/com/emilsjolander/components/StickyScrollViewItems/StickyScrollView.java
@@ -40,6 +40,16 @@ public class StickyScrollView extends ScrollView {
 	private boolean redirectTouchesToStickyView;
 	private boolean clippingToPadding;
 	private boolean clipToPaddingHasBeenSet;
+	
+	/**
+	 * True if onLayout has been called and before super.onLayout has been called.
+	 * False otherwise. 
+	 * 
+	 * During this time when this is true, we should not try to calculate any
+	 * views' dimensions as, if we are removing views, they could become null at
+	 * any time.
+	 */
+	public boolean isLayingOut = false;
 
 	private final Runnable invalidateRunnable = new Runnable() {
 
@@ -74,6 +84,8 @@ public class StickyScrollView extends ScrollView {
 	}
 	
 	private int getLeftForViewRelativeOnlyChild(View v){
+		if (isLayingOut)
+			return 0;
 		int left = v.getLeft();
 		while(v.getParent() != getChildAt(0)){
 			v = (View) v.getParent();
@@ -83,6 +95,8 @@ public class StickyScrollView extends ScrollView {
 	}
 	
 	private int getTopForViewRelativeOnlyChild(View v){
+		if (isLayingOut)
+			return 0;
 		int top = v.getTop();
 		while(v.getParent() != getChildAt(0)){
 			v = (View) v.getParent();
@@ -92,6 +106,8 @@ public class StickyScrollView extends ScrollView {
 	}
 	
 	private int getRightForViewRelativeOnlyChild(View v){
+		if (isLayingOut)
+			return 0;
 		int right = v.getRight();
 		while(v.getParent() != getChildAt(0)){
 			v = (View) v.getParent();
@@ -101,6 +117,8 @@ public class StickyScrollView extends ScrollView {
 	}
 	
 	private int getBottomForViewRelativeOnlyChild(View v){
+		if (isLayingOut)
+			return 0;
 		int bottom = v.getBottom();
 		while(v.getParent() != getChildAt(0)){
 			v = (View) v.getParent();
@@ -111,7 +129,9 @@ public class StickyScrollView extends ScrollView {
 
 	@Override
 	protected void onLayout(boolean changed, int l, int t, int r, int b) {
+		isLayingOut = true;
 		super.onLayout(changed, l, t, r, b);
+		isLayingOut = false;
 		if(!clipToPaddingHasBeenSet){
 			clippingToPadding = true;
 		}


### PR DESCRIPTION
added flag set to true during onLayout. The flag is used so we don't try to calculate dimensions of a view that might become null during layout (say if we are removing views).

I was getting this error when I removed views from the ScrollView's child and the get_ForViewRelativeOnlyChild methods were being called. During onLayout, the views that get_ForViewRelativeOnlyChild is trying to calculate the dimensions of might become null. So we should just return zero from get*ForViewRelativeOnlyChild during this time, as the info is likely garbage anyway.
