### PR TITLE
Updating to a more recent gradle to solve generated Resource index va…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.7.+'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
@@ -21,4 +21,4 @@ allprojects {
     }
 }
 
-apply plugin: 'android-reporting'
+apply plugin: 'com.android.reporting'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.1.0
+VERSION_NAME=2.0
 GROUP=se.emilsjolander
 
 POM_DESCRIPTION=A small android library for tagging views inside a ScrollView as "sticky" making them stick to the top of the scroll container until a new sticky view comes and takes it's place.

--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.emilsjolander.components.StickyScrollViewItems"
-    android:versionCode="1"
-    android:versionName="1.0" >
-
-    <uses-sdk
-        android:minSdkVersion="7"
-        android:targetSdkVersion="14" />
-
+    >
 </manifest>

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,8 +1,29 @@
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion '19.0.0'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 24
+        versionCode 2.0
+        versionName '2.0'
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    buildTypes {
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-project.txt'), 'proguard-rules.pro'
+        }
+        debug {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-project.txt'), 'proguard-rules.pro'
+        }
+    }
 
     sourceSets {
         main {
@@ -13,4 +34,4 @@ android {
     }
 }
 
-apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/eaa6b5404b7594e6c23b884fdc5795f545db55dd/gradle-mvn-push.gradle'
+// apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/eaa6b5404b7594e6c23b884fdc5795f545db55dd/gradle-mvn-push.gradle'

--- a/sample/AndroidManifest.xml
+++ b/sample/AndroidManifest.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.emilsjolander.components.StickyScrollViewItems"
-    android:versionCode="1"
-    android:versionName="1.0" >
-
-    <uses-sdk android:minSdkVersion="7" android:targetSdkVersion="14" />
 
     <application
         android:icon="@drawable/ic_launcher"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,16 +1,16 @@
-apply plugin: 'android'
+apply plugin: 'com.android'
 
 repositories {
     mavenCentral()
 }
 dependencies {
     compile project(':library')
-    compile 'com.android.support:support-v4:18.0.0'
+    compile 'com.android.support:support-v4:26.0.2'
 }
 
 android {
-    compileSdkVersion 18
-    buildToolsVersion '18.0.1'
+  compileSdkVersion 26
+  buildToolsVersion "26.0.2"
 
     sourceSets {
         main {


### PR DESCRIPTION
Updating to a more recent gradle and android build tools to solve generated Resource index value inconsistencies. Specifically, the index values for R.styleable.StickyScrollView_stuckShadowHeight and R.styleable.StickyScrollView_stuckShadowDrawable were transposed at runtime, leading to UnsupportedOperationException: "Can't convert to dimension: type=0x3" when inflating the layout when used library is used with newer Gradle (on line 90 or 98 respectively of StickyScrollView.java) should one or both of these attributes be set in the layout xml.
Incrementing version number as the build results may not be backwards compatible.