### PR TITLE
Correct XML tags for usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ dependencies {
 
 Usage
 -----
-First of all replace any instance of `ScrollView` with `StickyScrollView`.
+First of all replace any instance of `ScrollView` with `com.emilsjolander.components.StickyScrollViewItems.StickyScrollView`.
 So you go from this:
 ```xml
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
@@ -23,16 +23,16 @@ So you go from this:
 ```
 to this:
 ```xml
-<StickyScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.emilsjolander.components.StickyScrollViewItems.StickyScrollView xmlns:android="http://schemas.android.com/apk/res/android"
 	android:layout_height="match_parent" android:layout_width="match_parent"
 	android:id="@+id/sticky_scroll">
 	<!-- scroll view child goes here -->
-</StickyScrollView>
+</com.emilsjolander.components.StickyScrollViewItems.StickyScrollView>
 ```
 
 As with a regular `ScrollView` you are only allowed one child. But that child can contain any number of children. It is these children or any of their children that can be tagged as a sticky view. If you want t view to stick to the top when you scroll passed it add a `sticky` tag with the `android:tag` attribute to it like this:
 ```xml
-<StickyScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.emilsjolander.components.StickyScrollViewItems.StickyScrollView xmlns:android="http://schemas.android.com/apk/res/android"
 	android:id="@+id/sticky_scroll"
 	android:layout_height="match_parent" android:layout_width="match_parent">
 
@@ -51,7 +51,7 @@ As with a regular `ScrollView` you are only allowed one child. But that child ca
 
 	</LinearLayout>
 
-</StickyScrollView>
+</com.emilsjolander.components.StickyScrollViewItems.StickyScrollView>
 ```
 
 There are also two additional flags that can be set on views that were added to optimize performance for the most usual cases. If the view you want to stick either has transparency or does not have a constant representation than you must supply one or both of the following flags. `-hastransparancy` for views that have transparancy and `-nonconstant` for views that will change appearance during there sticky time (examples are buttons with pressed states as well as progress spinners).
@@ -60,14 +60,14 @@ So this ends up with 4 different ways to tag a view as sticky resulting is sligh
 
 If you want to add a shadow drawable below the stuck items, you must declare a namespace to find the shadow attributes `xmlns:whatever="http://schemas.android.com/apk/res-auto"`. Usually you do this in the root layout element in you layout.xml file. You can then specify the shadow drawable with `whatever:stuckShadowDrawable=""` and the shadow height with `whatever:stuckShadowHeight=""` in xml. Note that when left unspecified, the default shadow height is 10dip.
 ```xml
-<StickyScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.emilsjolander.components.StickyScrollViewItems.StickyScrollView xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:whatever="http://schemas.android.com/apk/res-auto"
   android:layout_height="match_parent" android:layout_width="match_parent"
   android:id="@+id/sticky_scroll"
   whatever:stuckShadowDrawable="@drawable/sticky_shadow_default"
   whatever:stuckShadowHeight="50dip" >
   <!-- scroll view child goes here -->
-</StickyScrollView>
+</com.emilsjolander.components.StickyScrollViewItems.StickyScrollView>
 ```
 
 These shadow height and drawable can also be set programatically. Note that, unlike the xml attribute, `setShadowHeight(pixels)` only takes the values in pixels.


### PR DESCRIPTION
When using the gradle dependency, the `com.emilsjolander.components.StickyScrollViewItems.` prefix has to be used in the `StickyScrollView` XML tags. Added as clarification.